### PR TITLE
deallocate pointer to bytes

### DIFF
--- a/Sources/Piz/Piz.swift
+++ b/Sources/Piz/Piz.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// A simple unzipper.
-public struct Piz {
+public class Piz {
   /// Zip data.
   public let data: Data
 
@@ -21,13 +21,17 @@ public struct Piz {
     _bytes = bytes
     _cdirs = dirs
   }
+    
+  deinit {
+    _bytes.deallocate()
+  }
 
   /// Creates an instance from `fileURL`.
-  public init?(fileURL: URL) {
+  public convenience init?(fileURL: URL) {
     guard let data = try? Data(contentsOf: fileURL) else { return nil }
     self.init(data: data)
   }
-
+    
   private let _bytes: UnsafePointer<UInt8>
   private let _cdirs: [String: CDir]
 }


### PR DESCRIPTION
Change Piz to class. Added deinit function to deallocate the pointer. It appears that having a pointer in a struct does not deallocate the pointers correctly in this case. A better solution may exist but this is working for my use case. 